### PR TITLE
feat: :construction_worker: Added request command

### DIFF
--- a/src/commands/uib/course.ts
+++ b/src/commands/uib/course.ts
@@ -25,11 +25,11 @@ class RequestCommand extends Command {
   }
 
   run = async (message: CommandoMessage, { subject }: { subject: string }): Promise<Message | Message[]> => {
-    if (subject == undefined) {
+    if (subject === undefined || subject.trim() === "") {
       return await message.reply("You need to specify the subject to ask about");
     }
 
-    const inputSubject = subject.toUpperCase();
+    const inputSubject = subject.toUpperCase().trim();
 
     const exams = await readPage();
     if (!exams.has(inputSubject)) {

--- a/src/commands/uib/course.ts
+++ b/src/commands/uib/course.ts
@@ -1,0 +1,92 @@
+import { Command, CommandoClient, CommandoMessage } from "discord.js-commando";
+import { Message, GuildChannel, Collection } from "discord.js";
+import logger from "../../utils/logger";
+import { Course, readPage } from "../../modules/exams";
+
+class RequestCommand extends Command {
+  constructor(client: CommandoClient) {
+    super(client, {
+      name: "request",
+      aliases: ["fag", "emne"],
+      group: "uib",
+      memberName: "request",
+      description: "Make channel for course x plz",
+      argsPromptLimit: 0,
+      args: [
+        {
+          key: "subject",
+          prompt: "The course you need a text channel for",
+          type: "string",
+          validate: undefined,
+          default: "",
+        },
+      ],
+    });
+  }
+
+  run = async (message: CommandoMessage, { subject }: { subject: string }): Promise<Message | Message[]> => {
+    if (subject == undefined) {
+      return await message.reply("You need to specify the subject to ask about");
+    }
+
+    const inputSubject = subject.toUpperCase();
+
+    const exams = await readPage();
+    if (!exams.has(inputSubject)) {
+      logger.warn({
+        message: "Missing course",
+        userId: message.author.id,
+        subject: inputSubject,
+      });
+      return await message.reply(`Sorry, no course with the code ${inputSubject} found... try again`);
+    }
+
+    const course = exams.get(inputSubject) as Course;
+
+    logger.info({
+      message: "Subject was inquired about",
+      userId: message.author.id,
+      subject: inputSubject,
+    });
+
+    const guild = message.guild;
+    const channelCache = guild.channels.cache; // Cache liste av kanaler
+    // Sjekk om det finnes en kanal med samme emnekode
+    const channelExits = channelCache.some((channel) => channel.name.toLowerCase() === course.code.toLowerCase());
+    if (channelExits) {
+      return await message.say(`A channel for ${inputSubject} already exists.`);
+    } else {
+      const category = this.getCategoryChannel(course, channelCache); // Finn hvilken kategori som er parent av den nye kanalen
+      await message.guild.channels.create(course.code.toLowerCase(), { type: "text", parent: category });
+      return await message.say(`A channel for ${inputSubject} has been created.`);
+    }
+    return await message.say("An error has occured");
+  };
+
+  getCategoryChannel = (course: Course, channelCache: Collection<string, GuildChannel>): GuildChannel | undefined => {
+    // Matte fag
+    if (course.code.includes("MAT") || course.code.includes("STAT")) {
+      return channelCache.find((category) => category.name == "MAT");
+
+      // INF Fag
+    } else if (course.code.includes("INF")) {
+      switch (course.code.charAt(3)) {
+        case "1":
+          return channelCache.find((category: { name: string }) => category.name == "INF1XX");
+          break;
+        case "2":
+          return channelCache.find((category) => category.name == "INF2XX");
+          break;
+        case "3":
+          return channelCache.find((category) => category.name == "INF3XX");
+          break;
+        default:
+          return channelCache.find((category) => category.name == "Other"); // Default til other, f.eks med BINF
+          break;
+      }
+    }
+    return channelCache.find((category) => category.name == "Other"); // Default til other, f.eks med BINF
+  };
+}
+
+export default RequestCommand;

--- a/src/commands/uib/course.ts
+++ b/src/commands/uib/course.ts
@@ -66,26 +66,25 @@ class RequestCommand extends Command {
   getCategoryChannel = (course: Course, channelCache: Collection<string, GuildChannel>): GuildChannel | undefined => {
     // Matte fag
     if (course.code.includes("MAT") || course.code.includes("STAT")) {
-      return channelCache.find((category) => category.name == "MAT");
+      return channelCache.find((category) => category.name === "MAT");
 
       // INF Fag
-    } else if (course.code.includes("INF")) {
+    } else if (course.code.substring(0, 3) === "INF") {
       switch (course.code.charAt(3)) {
         case "1":
-          return channelCache.find((category: { name: string }) => category.name == "INF1XX");
+          return channelCache.find((category) => category.id === "744961179612610700"); // INF1xx Kategori
           break;
         case "2":
-          return channelCache.find((category) => category.name == "INF2XX");
+          return channelCache.find((category) => category.id === "744961214878056449"); // INF2xx Kategori
           break;
         case "3":
-          return channelCache.find((category) => category.name == "INF3XX");
+          return channelCache.find((category) => category.id === "744961536367525948"); // INF3xx Kategori
           break;
         default:
-          return channelCache.find((category) => category.name == "Other"); // Default til other, f.eks med BINF
           break;
       }
     }
-    return channelCache.find((category) => category.name == "Other"); // Default til other, f.eks med BINF
+    return channelCache.find((category) => category.id === "744961383380287589"); // Default til other, f.eks med BINF
   };
 }
 


### PR DESCRIPTION
>     * Verken `INF207` eller `INF143A` ble plassert i noen kategori, de bare havnet frittstående
category.name har funky case, burde egentlig bruke cache.find(cat => cat.id == "$ID")

>     * Det funket ikke å lage `DAT251` siden den ikke er i eksamensinfofila, så den `default`-branchen i `switchen` hvor du finner kategori funker ikke
Den funksjonen er kun for å hente ut hvilken kategori, i discord serveren, de skal plasseres i.
`Sorry, no course with the code DAT251 found... try again` 
Betyr at den ikke fant faget i eksamensfila. User-input stringen inputSubject brukes ikke videre, og faget DAT251 vil aldri komme inn i switch casen. 

Velger å ikke stole på user input. Den bruker ikke input til noe annet en å finne faget i egen database over fag.

>     * Når jeg prøvde uten et argument fikk jeg `Sorry, no course with the code  found... try again` som feil, tror det er fordi du gjør `if (subject == undefined)`, om du gjør `if (subject === "")` tror jeg den blir riktig. Har samme problem i f.eks. `insult` men skjønner ikke hvorfor den er ei tom streng og ikke undefined... Er kanskje mer riktig å gjøre `if (!subject)` i steden så man sjekker for begge 🤔

Hadde noen problemer med at den prøvde å kalle undefined.toUpperCase().trim().
Foreslår: 
`if (subject === undefined || subject.trim() === "")`, fordi 

```javascript
a = undefined;
> undefined
a === ""
> false
a == ""
> false
```