### PR TITLE
Old commands deprecation

### DIFF
--- a/src/client/client.ts
+++ b/src/client/client.ts
@@ -40,5 +40,13 @@ export class DiscordClient extends Client {
       logger.debug(`Received command ${interaction.commandName}`);
       void this.commandHandler.handle(interaction);
     });
+
+    this.on("messageCreate", (message) => {
+      const cmd = message.content.split(' ')[0];
+      if (cmd.startsWith(this.config.discord.prefix)) {
+        const cmdContent = cmd.slice(1);
+        message.reply(`Commands starting with ${this.config.discord.prefix} are deprecated, try \`/${cmdContent}\` instead.`);
+      }
+    });
   }
 }

--- a/src/client/config.ts
+++ b/src/client/config.ts
@@ -3,6 +3,7 @@ export interface Config {
     token: string;
     appId: string;
     guildId: string;
+    prefix: string;
   };
 }
 
@@ -19,6 +20,7 @@ export const getConfig = (): Config => {
       token: getEnvVar("DISCORD_TOKEN"),
       appId: getEnvVar("DISCORD_APP_ID"),
       guildId: getEnvVar("DISCORD_GUILD_ID"),
+      prefix: getEnvVar("DISCORD_PREFIX"),
     },
   };
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,6 +10,8 @@ const botIntents = [
   Intents.FLAGS.GUILD_MEMBERS,
   Intents.FLAGS.GUILD_PRESENCES,
   Intents.FLAGS.GUILD_VOICE_STATES,
+  Intents.FLAGS.GUILD_MESSAGES,
+  Intents.FLAGS.DIRECT_MESSAGES,
 ];
 
 const client = new DiscordClient(getConfig(), { intents: botIntents });

--- a/src/utils/courses.ts
+++ b/src/utils/courses.ts
@@ -57,6 +57,7 @@ export const getPersistentData = async (): Promise<PersistentData | undefined> =
   } catch (error) {
     // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
     logger.error(`Unable to fetch course information, reason: ${error}`);
+    return undefined;
   }
 
   logger.error("Unable to fetch course information, reason unknown.");


### PR DESCRIPTION
Added a feature that responds to a user trying to use the old `!<command>` syntax and tells them to use the new `/<command>` syntax instead. Whenever people start to get used to the new syntax we can probably revert this pr.